### PR TITLE
Fix react import casing on FloatingActionButton

### DIFF
--- a/src/components/FloatingActionButton/FloatingActionButton.js
+++ b/src/components/FloatingActionButton/FloatingActionButton.js
@@ -1,4 +1,4 @@
-import * as React from 'React';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import FabM from '@mui/material/Fab';
 import Icon from '../Icon/Icon';


### PR DESCRIPTION
This fixed a error or warning message while using uxpin-merge

I used the github editor, I think it may have changed the line endings or something