### PR TITLE
Fix SwitchWithLabel casing in uxpin.config.js

### DIFF
--- a/uxpin.config.js
+++ b/uxpin.config.js
@@ -26,7 +26,7 @@ module.exports = {
             'src/components/Rating/Rating.js',
             'src/components/Select/Select.js',
             'src/components/Switch/Switch.js',
-            'src/components/SwitchWithlabel/SwitchWithlabel.js',
+            'src/components/SwitchWithLabel/SwitchWithLabel.js',
             // 'src/components/SwitchGroup/SwitchGroup.js',  <-- NOT CHANGING STATE IN PREVIEW
             'src/components/TextField/TextField.js',
             'src/components/ToggleButton/ToggleButton.js',


### PR DESCRIPTION
This fixed an error message while using uxpin-merge

I used the github editor, I think it may have changed the line endings or something