### PR TITLE
Render `Dialog` and `Snackbar` components in a React.Portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "@uxpin/merge-cli": "^2.8.0",
+    "@uxpin/merge-cli": "^2.9.0",
     "date-fns": "^2.27.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -8,10 +8,12 @@ import OriginalDialog from '@mui/material/Dialog';
  */
 
 function Dialog(props) {
-  const { children, open, ...otherProps } = props;
+  const { children, open, sx, ...otherProps } = props;
   const [isOpen, setIsOpen] = React.useState(open);
 
   React.useEffect(() => setIsOpen(open), [open]);
+
+  const styles = { ...sx, position: 'absolute' }; // override `fixed` position to display related to the Preview main area
 
   return (
     <OriginalDialog
@@ -19,12 +21,7 @@ function Dialog(props) {
       onClose={() => setIsOpen(false)}
       TransitionProps={{ tabIndex: 'null' }}
       disablePortal={true}
-      style={{
-        minWidth: '300px',
-        minHeight: '300px',
-        width: '100%',
-        height: '100%',
-      }}
+      sx={styles}
       {...otherProps}
     >
       {children}
@@ -76,6 +73,11 @@ Dialog.propTypes = {
   maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
 
   /**
+   * If `true`, the dialog stretches to `maxWidth`.
+   */
+  fullWidth: PropTypes.bool,
+
+  /**
    *  @uxpinignoreprop
    */
   children: PropTypes.node,
@@ -118,12 +120,6 @@ Dialog.propTypes = {
   scroll: PropTypes.oneOf(['body', 'paper']),
 
   onClose: PropTypes.func,
-
-  /**
-   * If `true`, the dialog stretches to `maxWidth`.
-   * @uxpinignoreprop
-   */
-  fullWidth: PropTypes.bool,
 
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -1,33 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import DialogM from '@mui/material/Dialog';
+import OriginalDialog from '@mui/material/Dialog';
 
 /**
  * @uxpindocurl https://mui.com/api/dialog/#main-content
+ * @uxpinuseportal
  */
 
 function Dialog(props) {
-  const { uxpinRef, ...other } = props;
+  const { children, open, ...otherProps } = props;
+  const [isOpen, setIsOpen] = React.useState(open);
 
-  const [open, setOpen] = React.useState(props.open);
-
-  React.useEffect(() => setOpen(props.open), [props]);
-
-  const handleClickOpen = () => {
-    setOpen(true);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
+  React.useEffect(() => setIsOpen(open), [open]);
 
   return (
-    <DialogM
-      open={open}
-      onClose={() => setOpen(false)}
+    <OriginalDialog
+      open={isOpen}
+      onClose={() => setIsOpen(false)}
       TransitionProps={{ tabIndex: 'null' }}
-      // disableEnforceFocus
-      // keepMounted
       disablePortal={true}
       style={{
         minWidth: '300px',
@@ -35,10 +25,10 @@ function Dialog(props) {
         width: '100%',
         height: '100%',
       }}
-      {...props}
+      {...otherProps}
     >
-      {props.children}
-    </DialogM>
+      {children}
+    </OriginalDialog>
   );
 }
 
@@ -126,15 +116,6 @@ Dialog.propTypes = {
    * Determine the container for scrolling the dialog.
    */
   scroll: PropTypes.oneOf(['body', 'paper']),
-  /**
-   * Enter event to use with UXPin interactions.
-   */
-  onEnter: PropTypes.func,
-
-  /**
-   * Exit event to use with UXPin interactions.
-   */
-  onExit: PropTypes.func,
 
   onClose: PropTypes.func,
 

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import DialogM from "@mui/material/Dialog";
-
+import DialogM from '@mui/material/Dialog';
 
 /**
  * @uxpindocurl https://mui.com/api/dialog/#main-content
  */
 
 function Dialog(props) {
-
   const { uxpinRef, ...other } = props;
 
   const [open, setOpen] = React.useState(props.open);
@@ -27,16 +25,21 @@ function Dialog(props) {
     <DialogM
       open={open}
       onClose={() => setOpen(false)}
-      TransitionProps={ {tabIndex: "null"} }
+      TransitionProps={{ tabIndex: 'null' }}
       // disableEnforceFocus
       // keepMounted
       disablePortal={true}
-      style={{ minWidth: "300px", minHeight: "300px", width: "100%", height: "100%" }}
+      style={{
+        minWidth: '300px',
+        minHeight: '300px',
+        width: '100%',
+        height: '100%',
+      }}
       {...props}
     >
       {props.children}
     </DialogM>
-  )
+  );
 }
 
 Dialog.propTypes = {
@@ -74,16 +77,13 @@ Dialog.propTypes = {
   /** @uxpinignoreprop */
   onBackdropClick: PropTypes.func,
 
-
   /**
    * Determine the max width of the dialog.
    * The dialog width grows with the size of the screen, this property is useful
    * on the desktop where you might need some coherent different width size across your
    * application. Set to `false` to disable `maxWidth`.
    */
-  maxWidth: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl", false]),
-
-
+  maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
 
   /**
    *  @uxpinignoreprop
@@ -97,8 +97,8 @@ Dialog.propTypes = {
   PaperComponent: PropTypes.elementType,
 
   /**
-   * The component used for the transition. 
-   * Follow this guide: https://mui.com/components/transitions/#transitioncomponent-prop 
+   * The component used for the transition.
+   * Follow this guide: https://mui.com/components/transitions/#transitioncomponent-prop
    * to learn more about the requirements for this component.
    */
   /** @uxpinignoreprop */
@@ -127,31 +127,29 @@ Dialog.propTypes = {
    */
   scroll: PropTypes.oneOf(['body', 'paper']),
   /**
- * Enter event to use with UXPin interactions.
- */
+   * Enter event to use with UXPin interactions.
+   */
   onEnter: PropTypes.func,
 
   /**
    * Exit event to use with UXPin interactions.
    */
   onExit: PropTypes.func,
-  
+
   onClose: PropTypes.func,
 
   /**
- * If `true`, the dialog stretches to `maxWidth`.
- * @uxpinignoreprop
- */
+   * If `true`, the dialog stretches to `maxWidth`.
+   * @uxpinignoreprop
+   */
   fullWidth: PropTypes.bool,
 
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles. 
+   * The system prop that allows defining system overrides as well as additional CSS styles.
    * See the `sx` page for more details. https://mui.com/system/the-sx-prop/
    */
   /** */
   sx: PropTypes.object,
-
 };
-
 
 export default Dialog;

--- a/src/components/Dialog/presets/0-default.jsx
+++ b/src/components/Dialog/presets/0-default.jsx
@@ -1,18 +1,17 @@
-import React from "react";
-import Button from "../../Button/Button";
-import Dialog from "../Dialog";
-import DialogActions from "../../DialogActions/DialogActions"
-import DialogContent from "../../DialogContent/DialogContent";
-import DialogContentText from "../../DialogContentText/DialogContentText";
-import DialogTitle from "../../DialogTitle/DialogTitle";
-
+import React from 'react';
+import Button from '../../Button/Button';
+import Dialog from '../Dialog';
+import DialogActions from '../../DialogActions/DialogActions';
+import DialogContent from '../../DialogContent/DialogContent';
+import DialogContentText from '../../DialogContentText/DialogContentText';
+import DialogTitle from '../../DialogTitle/DialogTitle';
 
 export default (
   <Dialog
-    uxpId="3" 
-    aria-labelledby="alert-dialog-title"
     aria-describedby="alert-dialog-description"
+    aria-labelledby="alert-dialog-title"
     open={true}
+    uxpId="3"
   >
     <DialogTitle id="alert-dialog-title" uxpId="4">
       {"Use Google's location service?"}
@@ -30,4 +29,4 @@ export default (
       </Button>
     </DialogActions>
   </Dialog>
-  );
+);

--- a/src/components/Dialog/presets/0-default.jsx
+++ b/src/components/Dialog/presets/0-default.jsx
@@ -14,7 +14,7 @@ export default (
     aria-describedby="alert-dialog-description"
     open={true}
   >
-    <DialogTitle id="alert-dialog-title" close={true} uxpId="4">
+    <DialogTitle id="alert-dialog-title" uxpId="4">
       {"Use Google's location service?"}
     </DialogTitle>
     <DialogContent uxpId="5">

--- a/src/components/Snackbar/Snackbar.js
+++ b/src/components/Snackbar/Snackbar.js
@@ -9,16 +9,13 @@ import Icon from '../Icon/Icon';
  * @uxpindocurl https://mui.com/components/skeleton/#main-content
  */
 export default function Snackbar(props) {
-
   const { uxpinRef, ...other } = props;
 
   const [open, setOpen] = React.useState(props.open);
 
-
   React.useEffect(() => {
-    setOpen(props.open)
+    setOpen(props.open);
   }, [props.open]); // Only re-run the effect if open prop changes
-
 
   const handleClose = (event, reason) => {
     if (reason === 'clickaway') {
@@ -29,14 +26,13 @@ export default function Snackbar(props) {
   };
 
   const action = (
-    <React.Fragment >
-      <div >
-        {props.undo ?
-          <Button color="primary" size="small" onClick={handleClose} >
+    <React.Fragment>
+      <div>
+        {props.undo ? (
+          <Button color="primary" size="small" onClick={handleClose}>
             UNDO
           </Button>
-          :
-          null}
+        ) : null}
 
         {props.children}
         <IconButton
@@ -51,22 +47,13 @@ export default function Snackbar(props) {
     </React.Fragment>
   );
 
-  return (
-    <SnackbarM
-      {...other}
-      open={open}
-      action={action}
-      ref={uxpinRef}
-    />
-  );
+  return <SnackbarM {...other} open={open} action={action} ref={uxpinRef} />;
 }
 
-
 Snackbar.propTypes = {
-
   /**
- * The message to display.
- */
+   * The message to display.
+   */
   message: PropTypes.string,
 
   /**
@@ -75,8 +62,8 @@ Snackbar.propTypes = {
   open: PropTypes.bool,
 
   /**
- * If true, the undo button is shown.
- */
+   * If true, the undo button is shown.
+   */
   undo: PropTypes.bool,
 
   /**
@@ -86,23 +73,23 @@ Snackbar.propTypes = {
   action: PropTypes.node,
 
   /**
-   * The anchor of the Snackbar. 
+   * The anchor of the Snackbar.
    * On smaller screens, the component grows to occupy all the available width, the horizontal alignment is ignored.
    * @uxpinignoreprop
    */
   actionOrigin: PropTypes.object,
 
   /**
-   * The number of milliseconds to wait before automatically calling the onClose function. 
-   * onClose should then set the state of the open prop to hide the Snackbar. 
+   * The number of milliseconds to wait before automatically calling the onClose function.
+   * onClose should then set the state of the open prop to hide the Snackbar.
    * This behavior is disabled by default with the null value.
-* @uxpinignoreprop
+   * @uxpinignoreprop
    */
   autoHideDuration: PropTypes.number,
 
   /**
    * The content of the component.
-    * @uxpinignoreprop
+   * @uxpinignoreprop
    */
   children: PropTypes.node,
 
@@ -131,23 +118,20 @@ Snackbar.propTypes = {
   disableWindowBlurListener: PropTypes.bool,
 
   /**
-   * When displaying multiple consecutive Snackbars from a parent rendering a single <Snackbar/>, add the key prop to ensure independent treatment of each message. 
+   * When displaying multiple consecutive Snackbars from a parent rendering a single <Snackbar/>, add the key prop to ensure independent treatment of each message.
    * e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled.
    * @uxpinignoreprop
    */
   key: PropTypes.node,
 
-
-
   /**
-   * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop. 
+   * Callback fired when the component requests to be closed. Typically onClose is used to set state in the parent component, which is used to control the Snackbar open prop.
    * The reason parameter can optionally be used to control the response to onClose, for example ignoring clickaway.
    */
   onClose: PropTypes.func,
 
-
   /**
-   * The number of milliseconds to wait before dismissing after user interaction. If autoHideDuration prop isn't specified, it does nothing. 
+   * The number of milliseconds to wait before dismissing after user interaction. If autoHideDuration prop isn't specified, it does nothing.
    * If autoHideDuration prop is specified but resumeHideDuration isn't, we default to autoHideDuration / 2 ms.
    * @uxpinignoreprop
    */
@@ -160,7 +144,7 @@ Snackbar.propTypes = {
   TransitionComponent: PropTypes.elementType,
 
   /**
-   * The duration for the transition, in milliseconds. 
+   * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
   // transitionDuration: PropTypes.number | { appear?: number, enter?: number, exit?: number },
@@ -175,4 +159,4 @@ Snackbar.propTypes = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.object,
-}
+};

--- a/src/components/Snackbar/Snackbar.js
+++ b/src/components/Snackbar/Snackbar.js
@@ -1,53 +1,64 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@mui/material/Button';
-import SnackbarM from '@mui/material/Snackbar';
+import OriginalSnackbar from '@mui/material/Snackbar';
+
 import IconButton from '../IconButton/IconButton';
-import Icon from '../Icon/Icon';
 
 /**
- * @uxpindocurl https://mui.com/components/skeleton/#main-content
+ * @uxpindocurl https://mui.com/material-ui/react-snackbar/
+ * @uxpinuseportal
  */
 export default function Snackbar(props) {
-  const { uxpinRef, ...other } = props;
+  const { horizontal, open, sx, undo, uxpinRef, vertical, ...other } = props;
 
-  const [open, setOpen] = React.useState(props.open);
+  const [isOpen, setIsOpen] = React.useState(open);
 
   React.useEffect(() => {
-    setOpen(props.open);
-  }, [props.open]); // Only re-run the effect if open prop changes
+    setIsOpen(open);
+  }, [open]); // Only re-run the effect if open prop changes
 
   const handleClose = (event, reason) => {
     if (reason === 'clickaway') {
+      // prevents from closing in the UXPin Editor when switching props
       return;
     }
 
-    setOpen(false);
+    setIsOpen(false);
   };
 
-  const action = (
-    <React.Fragment>
-      <div>
-        {props.undo ? (
-          <Button color="primary" size="small" onClick={handleClose}>
-            UNDO
-          </Button>
-        ) : null}
+  const anchorOrigin = { vertical, horizontal };
+  const styles = { ...sx, position: 'absolute' }; // override `fixed` position to display related to the Preview main area
 
-        {props.children}
-        <IconButton
-          size="small"
-          aria-label="close"
-          color="inherit"
-          onClick={handleClose}
-        >
-          <Icon fontSize="small">close</Icon>
-        </IconButton>
-      </div>
-    </React.Fragment>
+  const action = (
+    <>
+      {undo && (
+        <Button color="primary" size="small" onClick={() => setIsOpen(false)}>
+          Undo
+        </Button>
+      )}
+      <IconButton
+        size="small"
+        aria-label="close"
+        color="inherit"
+        onClick={() => setIsOpen(false)}
+      >
+        close
+      </IconButton>
+    </>
   );
 
-  return <SnackbarM {...other} open={open} action={action} ref={uxpinRef} />;
+  return (
+    <OriginalSnackbar
+      {...other}
+      onClose={handleClose}
+      open={isOpen}
+      anchorOrigin={anchorOrigin}
+      action={action}
+      ref={uxpinRef}
+      sx={styles}
+    />
+  );
 }
 
 Snackbar.propTypes = {
@@ -159,4 +170,13 @@ Snackbar.propTypes = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.object,
+
+  // New properties added to be able to set up the position on the screen from the UXPin Editor
+  vertical: PropTypes.oneOf(['top', 'bottom']),
+  horizontal: PropTypes.oneOf(['left', 'center', 'right']),
+};
+
+Snackbar.defaultProps = {
+  vertical: 'bottom',
+  horizontal: 'left',
 };

--- a/src/components/Snackbar/presets/0-default.jsx
+++ b/src/components/Snackbar/presets/0-default.jsx
@@ -6,5 +6,6 @@ export default (
     uxpId='Snackbar-1' 
     open={true}
     message="Note archived"
+    undo
   />
 );

--- a/src/components/Snackbar/presets/0-default.jsx
+++ b/src/components/Snackbar/presets/0-default.jsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import Snackbar from '../Snackbar';
 
 export default (
-  <Snackbar 
-    uxpId='Snackbar-1' 
-    open={true}
+  <Snackbar
     message="Note archived"
-    undo
+    open={true}
+    undo={true}
+    uxpId="Snackbar-1"
   />
 );

--- a/uxpin.config.js
+++ b/uxpin.config.js
@@ -197,5 +197,5 @@ module.exports = {
     wrapper: 'src/components/UXPinWrapper/UXPinWrapper.js',
     webpackConfig: 'uxpin.webpack.config.js',
   },
-  name: 'material-ui-uxpin'
+  name: 'MUI 5 with UXPin Merge'
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,6 +2692,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@colors/colors@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@csstools/normalize.css@*":
   version "12.0.0"
   resolved "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz#a9583a75c3f150667771f30b60d9f059473e62c4"
@@ -4787,16 +4792,17 @@
     "@typescript-eslint/types" "5.11.0"
     eslint-visitor-keys "^3.0.0"
 
-"@uxpin/merge-cli@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/@uxpin/merge-cli/-/merge-cli-2.8.0.tgz#76a04e0b37e372f45348bd7cd5203f1ccec3b34b"
-  integrity sha512-OtE8lQs2nfO6otyKiBxdE3+x6goay2a8cChNMS8ZlhT6z4jH9dMVQ0K+RhllSheZwrn0PSnk1ExWHGqdqNLoBw==
+"@uxpin/merge-cli@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@uxpin/merge-cli/-/merge-cli-2.9.0.tgz#9a42ebba405d581bbac47ed1c9e951df1c4762f8"
+  integrity sha512-EsFwS9Ymhky/2dIFEXnXoIDnOVy21OmitASNqKWoHwaklrSSYJkmS70yRQxoRnb468vwNxjEc0aw5fGiHNNAxw==
   dependencies:
     "@babel/core" "^7.2.2"
     "@babel/plugin-proposal-class-properties" "^7.2.3"
     "@babel/preset-env" "^7.13.5"
     "@babel/preset-flow" "^7.0.0"
     "@babel/preset-react" "^7.0.0"
+    "@colors/colors" "^1.5.0"
     "@types/yargs" "^16.0.0"
     "@uxpin/react-docgen-better-proptypes" "^0.1.1"
     acorn-loose "^8.0.2"
@@ -4805,7 +4811,6 @@
     chokidar "^3.5.1"
     clean-stacktrace "^1.1.0"
     clean-stacktrace-relative-paths "^1.0.4"
-    colors "^1.1.3"
     commander "^2.11.0"
     formidable "^1.2.1"
     fs-extra "^7.0.0"
@@ -6554,11 +6559,6 @@ colorette@^2.0.10:
   version "2.0.16"
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
-
-colors@^1.1.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"


### PR DESCRIPTION
## Goal

- Render MUI `Dialog` and `Snackbar` using a React Portal in UXPin Preview, taking advantage of the latest feature of the Merge CLI (`2.9.0`)
- Cleanup using `Prettier` (TODO: apply to all components in the code base), removal of not valid props

## About Portal components

Sometimes you need to display some components outside the UXPin canvas, at a specific position on the screen.
For example, notification components (often called “toast” or “snack”) are often displayed at the top or the bottom of the screen.
Another common pattern in web applications is “modal” (or “dialog”) components that cover the whole screen.
To display these types of components correctly, you need to render them in what is called a [Portal](https://reactjs.org/docs/portals.html) in the React world.

Use the JSDoc comment “@uxpinuseporal” to enable this behavior.

```js
/**
 * @uxpinuseportal
 */
function Dialog(props) {
}
```

Note: Portal components can be dropped anywhere in the canvas, it does not matter when they are displayed in UXPin Preview.

## How to check

### Snackbar

- Add a `Snackbar` component to the canvas
- Try the different combinations of `Horizontal` and `Vertical` properties
- Switch to _Preview_ mode: the snackbat should be displayed at the right position of the screen

### Dialog

- Add a dialog to the canvas
- Set the property`open` to false to hide it
- Add a button with an interaction that sets the property `open` to `True`
- Switch to _Preview_ mode
- When clicking on the button, the Modal should be display and cover all the screen

## Screenshots

### Snackbar at the top left corner

![image](https://user-images.githubusercontent.com/5546996/208055331-54a2d259-898a-411b-a377-b12b39ef3ae5.png)

### Modal

![image](https://user-images.githubusercontent.com/5546996/208054240-a0b15a5d-9ed2-4e05-bdad-14b04c17d6d0.png)

